### PR TITLE
tp - stars rounding issue for books

### DIFF
--- a/hello-world/app/books/[bookId]/page.tsx
+++ b/hello-world/app/books/[bookId]/page.tsx
@@ -201,12 +201,12 @@ export default function BookDetails() {
             self.indexOf(genre) === index
           ) || [];
 
-        const ratingRes = await fetch(`https://openlibrary.org/works/${bookId}/ratings.json`);
-        let rating = 0;
-        if (ratingRes.ok) {
-          const ratingData = await ratingRes.json();
-          rating = ratingData.summary?.average || 0;
-        }
+          const ratingRes = await fetch(`https://openlibrary.org/works/${bookId}/ratings.json`);
+          let rating = 0;
+          if (ratingRes.ok) {
+            const ratingData = await ratingRes.json();
+            rating = ratingData.summary?.average || 0;
+          }
 
         const cleanDescription =
           typeof data.description === "string"
@@ -289,6 +289,9 @@ export default function BookDetails() {
   }
 
   const StarRating: React.FC<StarRatingProps> = ({ rating, maxStars = 5, isInput = false }) => {
+    // Round the rating for visual display purposes only
+    const displayRating = Math.round(rating * 2) / 2; // Rounds to nearest 0.5
+    
     return (
       <div className="flex space-x-1">
         {[...Array(maxStars)].map((_, index) => (
@@ -310,9 +313,9 @@ export default function BookDetails() {
           >
             <span 
               className={`text-2xl ${isInput ? 'cursor-pointer' : 'cursor-default'} ${
-                index + 1 <= rating 
+                index + 1 <= displayRating 
                   ? "text-[#3D2F2A]" 
-                  : index + 0.5 === rating 
+                  : index + 0.5 === displayRating 
                   ? "relative overflow-hidden inline before:content-['★'] before:absolute before:text-[#3D2F2A] before:overflow-hidden before:w-[50%] text-[#DFDDCE]" 
                   : "text-[#DFDDCE]"
               }`}
@@ -564,8 +567,5 @@ export default function BookDetails() {
       </div>
     </div>
   );
-
-
-
 }
 

--- a/hello-world/app/timeline/page.tsx
+++ b/hello-world/app/timeline/page.tsx
@@ -102,7 +102,7 @@ const FriendActivityPage: React.FC = () => {
                   <h3 className="text-lg font-semibold">{notification.senderName}</h3>
                   <p className="text-custom-brown font-medium">
                     Reviewed <span className="italic">{notification.bookTitle}</span> {" "}
-                    and rated it {notification.rating} stars
+                    and rated it {notification.rating} {notification.rating === 1 ? "star" : "stars"}
                   </p>
                   <p className="text-custom-brown mt-1">{notification.reviewText}</p>
                   <p className="text-xs text-custom-brown opacity-70 mt-2">

--- a/hello-world/package-lock.json
+++ b/hello-world/package-lock.json
@@ -19,7 +19,7 @@
         "next": "15.1.4",
         "node": "^18.20.6",
         "react": "^19.0.0",
-        "react-datepicker": "^8.1.0",
+        "react-datepicker": "^8.2.0",
         "react-dom": "^19.0.0",
         "react-leaflet": "^5.0.0",
         "recharts": "^2.15.1"
@@ -10138,10 +10138,9 @@
       }
     },
     "node_modules/react-datepicker": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-8.1.0.tgz",
-      "integrity": "sha512-11gIOrBGK1MOvl4+wxGv4YxTqXf+uoRPtKstYhb/P1cBdRdOP1sL26VE31apmDnvw8wSYfJe9AWwWbKqmM9tzw==",
-      "license": "MIT",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-8.2.0.tgz",
+      "integrity": "sha512-zmUSOKxLrdYA6+etDU8N/w3vC9BZ4qRQ9azvp1seFgW4kk7QZJLB9aB7PJcw/EYWOK/1X7un9rUMXWPlcuZ4dw==",
       "dependencies": {
         "@floating-ui/react": "^0.27.3",
         "clsx": "^2.1.1",

--- a/hello-world/package.json
+++ b/hello-world/package.json
@@ -22,7 +22,7 @@
     "next": "15.1.4",
     "node": "^18.20.6",
     "react": "^19.0.0",
-    "react-datepicker": "^8.1.0",
+    "react-datepicker": "^8.2.0",
     "react-dom": "^19.0.0",
     "react-leaflet": "^5.0.0",
     "recharts": "^2.15.1"


### PR DESCRIPTION
branch: tp-starsRound

To test:
- npm run build
- npm start
- Make sure book star rating on the book page rounds to the nearest .5 rating. ie 3.9 should have 4 visible stars, a rating of 4.3 should show 4.5 stars etc
- make sure a one-star rating on the timeline page reads as follows:
<img width="789" alt="image" src="https://github.com/user-attachments/assets/68d4e938-c420-4722-b1bf-8edd1c3f5212" />

closes #192 